### PR TITLE
Make logging more verbose + some other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,14 @@ Join the [Official Discord Server](https://discord.gg/FT3puape2A) for help.
 Some things to know before using it.
 
 -
-    1. You need to copy the `config.example.ini` and rename it to `~/.config/qBitManager/config.ini` (~ is your home directory, i.e C:\Users\{User})
+    1. You need to copy the `config.example.ini` and rename it to `~/.config/qBitManager/config.ini` (~ is your home directory, i.e `C:\Users\{User}`)
 -
-    2. I have Sonarr and Radarr both setup to add tags to all downloads.
+    2. I have [Sonarr](https://github.com/Sonarr/Sonarr) and [Radarr](https://github.com/Radarr/Radarr) both setup to add tags to all downloads.
 -
-    3. I have qBit setup to have to create subfolder for downloads and for the download folder to
+    3. I have qBit setup to have to create sub-folder for downloads and for the download folder to
        use subcategories.
 
-![image](https://user-images.githubusercontent.com/27962761/139117102-ec1d321a-1e64-4880-8ad1-ee2c9b805f92.png)
-
+    ![image](https://user-images.githubusercontent.com/27962761/139117102-ec1d321a-1e64-4880-8ad1-ee2c9b805f92.png)
 -
     4. Make sure to have [`ffprobe`](https://www.ffmpeg.org/download.html) added to your PATH.
 
@@ -47,14 +46,14 @@ Some things to know before using it.
 
 #### How to update the script
 - Activate your venv
-- Run `python -m pip install -U qBitr`
+- Run `python -m pip install -U qBitrr`
 
 #### Contributions
 
 - I'm happy with any PRs and suggested changes to the logic I just put it together dirty for my own use case.
 
 #### Example behaviour
-![image](https://user-images.githubusercontent.com/27962761/139675283-f1b09955-d9b3-448c-b64c-1de58c1cddcb.png)
+![image](https://user-images.githubusercontent.com/27962761/145681358-1354e8ac-0939-4800-8af8-562d80388909.png)
 
 
 ### Change Logs

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Some things to know before using it.
 - I'm happy with any PRs and suggested changes to the logic I just put it together dirty for my own use case.
 
 #### Example behaviour
-![image](https://user-images.githubusercontent.com/27962761/145681358-1354e8ac-0939-4800-8af8-562d80388909.png)
+![image](https://user-images.githubusercontent.com/27962761/145682638-6c3a4c20-2756-4b42-a6b9-c7b95ad99b36.png)
 
 
 ### Change Logs
@@ -63,4 +63,7 @@ Some things to know before using it.
  - Update 2021-12-11
    - Fix an edge case where the script would tell the Arr instance that the torrent couldn't be found too early resulting in its removal.
    - Make a release to PyPi
-   - Add the script to your PATH via `pip install` allowing you to start it by just running `qbitrr` 
+   - Add the script to your PATH via `pip install` allowing you to start it by just running `qbitrr`
+   - Update logging and several typo fixes
+   - Make the script listen for `~/.config/qBitManager/config.ini` and prioritize it if it exists - in a future release it will stop listening for `config.ini` in the current working dir.
+ 

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -558,7 +558,7 @@ class Arr:
                 if not path.exists():
                     self.timed_ignore_cache.add(torrent.hash)
                     self.logger.warning(
-                        "Missing Torrent: [State:torrent.state_enum] {torrent.name} ({torrent.hash}) - "
+                        "Missing Torrent: [{torrent.state_enum}] {torrent.name} ({torrent.hash}) - "
                         "File does not seem to exist: {path}",
                         torrent=torrent,
                         path=path,
@@ -1615,7 +1615,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1631,7 +1631,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1647,7 +1647,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1665,7 +1665,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1682,7 +1682,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1704,7 +1704,7 @@ class Arr:
                             "[Progress: {progress}%][Added On: {added}]"
                             "[Availability: {availability}%][Time Left: {timedelta}]"
                             "[Last active: {last_activity}] "
-                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                            "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
                             progress=round(torrent.progress * 100, 2),
                             availability=round(torrent.availability * 100, 2),
@@ -1728,7 +1728,7 @@ class Arr:
                             "[Progress: {progress}%][Added On: {added}]"
                             "[Availability: {availability}%][Time Left: {timedelta}]"
                             "[Last active: {last_activity}] "
-                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                            "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
                             progress=round(torrent.progress * 100, 2),
                             availability=round(torrent.availability * 100, 2),
@@ -1743,7 +1743,7 @@ class Arr:
                             "[Progress: {progress}%][Added On: {added}]"
                             "[Availability: {availability}%][Time Left: {timedelta}]"
                             "[Last active: {last_activity}] "
-                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                            "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
                             progress=round(torrent.progress * 100, 2),
                             availability=round(torrent.availability * 100, 2),
@@ -1764,7 +1764,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1782,7 +1782,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1798,7 +1798,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1823,7 +1823,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1842,7 +1842,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1866,7 +1866,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1890,7 +1890,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -1913,7 +1913,7 @@ class Arr:
                             "[Progress: {progress}%][Added On: {added}]"
                             "[Availability: {availability}%][Time Left: {timedelta}]"
                             "[Last active: {last_activity}] "
-                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                            "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
                             progress=round(torrent.progress * 100, 2),
                             availability=round(torrent.availability * 100, 2),
@@ -1929,7 +1929,7 @@ class Arr:
                                 "[Progress: {progress}%][Added On: {added}]"
                                 "[Availability: {availability}%][Time Left: {timedelta}]"
                                 "[Last active: {last_activity}] "
-                                "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                                "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                                 torrent=torrent,
                                 progress=round(torrent.progress * 100, 2),
                                 availability=round(torrent.availability * 100, 2),
@@ -1995,7 +1995,7 @@ class Arr:
                                     "[Progress: {progress}%][Added On: {added}]"
                                     "[Availability: {availability}%][Time Left: {timedelta}]"
                                     "[Last active: {last_activity}] "
-                                    "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                                    "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                                     torrent=torrent,
                                     progress=round(torrent.progress * 100, 2),
                                     availability=round(torrent.availability * 100, 2),
@@ -2018,7 +2018,7 @@ class Arr:
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -2516,7 +2516,7 @@ class PlaceHolderArr(Arr):
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),
@@ -2532,7 +2532,7 @@ class PlaceHolderArr(Arr):
                         "[Progress: {progress}%][Added On: {added}]"
                         "[Availability: {availability}%][Time Left: {timedelta}]"
                         "[Last active: {last_activity}] "
-                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
+                        "| [{torrent.state_enum}] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
                         progress=round(torrent.progress * 100, 2),
                         availability=round(torrent.availability * 100, 2),

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -558,7 +558,8 @@ class Arr:
                 if not path.exists():
                     self.timed_ignore_cache.add(torrent.hash)
                     self.logger.warning(
-                        "Missing Torrent: {torrent.name} ({torrent.hash}) - File does not seem to exist: {path}",
+                        "Missing Torrent: [State:torrent.state_enum] {torrent.name} ({torrent.hash}) - "
+                        "File does not seem to exist: {path}",
                         torrent=torrent,
                         path=path,
                     )
@@ -1173,14 +1174,16 @@ class Arr:
 
                     if self.quality_unmet_search and QualityMet:
                         self.logger.trace(
-                            "Quality Met | {SeriesTitle} | S{SeasonNumber:02d}E{EpisodeNumber:03d}",
+                            "Quality Met | {SeriesTitle} | "
+                            "S{SeasonNumber:02d}E{EpisodeNumber:03d}",
                             SeriesTitle=SeriesTitle,
                             SeasonNumber=SeasonNumber,
                             EpisodeNumber=EpisodeNumber,
                         )
 
                     self.logger.trace(
-                        "Updating database entry | {SeriesTitle} | S{SeasonNumber:02d}E{EpisodeNumber:03d} | {Title}",
+                        "Updating database entry | {SeriesTitle} | "
+                        "S{SeasonNumber:02d}E{EpisodeNumber:03d} | {Title}",
                         SeriesTitle=SeriesTitle,
                         SeasonNumber=SeasonNumber,
                         EpisodeNumber=EpisodeNumber,
@@ -1609,30 +1612,48 @@ class Arr:
                 if torrent.category == FAILED_CATEGORY:
                     self.logger.notice(
                         "Deleting manually failed torrent: "
-                        "[Progress: {progress}%][Time Left: {timedelta}] | "
-                        "{torrent.name} ({torrent.hash})",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
-                        timedelta=timedelta(seconds=torrent.eta),
                         progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.delete.add(torrent.hash)
                 # Bypass everything else if manually marked for rechecking
                 elif torrent.category == RECHECK_CATEGORY:
                     self.logger.notice(
                         "Re-cheking manually set torrent: "
-                        "[Progress: {progress}%][Time Left: {timedelta}] | "
-                        "{torrent.name} ({torrent.hash})",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
-                        timedelta=timedelta(seconds=torrent.eta),
                         progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.recheck.add(torrent.hash)
                 # Do not touch torrents that are currently "Checking".
                 elif self.is_ignored_state(torrent):
                     self.logger.trace(
-                        "Skipping torrent: Ignored state | {torrent.name} ({torrent.hash}) | "
-                        "{torrent.state_enum}",
+                        "Skipping torrent: Ignored state | "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     if torrent.state_enum == TorrentStates.QUEUED_DOWNLOAD:
                         self.recently_queue[torrent.hash] = time.time()
@@ -1640,17 +1661,34 @@ class Arr:
                 # Do not touch torrents recently resumed/reched (A torrent can temporarely stall after being resumed from a paused state).
                 elif torrent.hash in self.timed_ignore_cache:
                     self.logger.trace(
-                        "Skipping torrent: Marked for skipping | {torrent.name} ({torrent.hash})",
+                        "Skipping torrent: Marked for skipping | "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     continue
                 elif torrent.state_enum == TorrentStates.QUEUED_UPLOAD:
                     self.pause.add(torrent.hash)
                     self.skip_blacklist.add(torrent.hash)
                     self.logger.trace(
-                        "Pausing torrent: Queued Upload | {torrent.name} ({torrent.hash}) | "
-                        "{torrent.state_enum}",
+                        "Pausing torrent: Queued Upload | "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                 # Process torrents who have stalled at this point, only mark from for deletion if they have been added more than "IgnoreTorrentsYoungerThan" seconds ago
                 elif torrent.state_enum in (
@@ -1663,10 +1701,16 @@ class Arr:
                     ):
                         self.logger.info(
                             "Deleting Stale torrent: "
-                            "[Progress: {progress}%][Added On: {added}] | {torrent.name} ({torrent.hash})",
+                            "[Progress: {progress}%][Added On: {added}]"
+                            "[Availability: {availability}%][Time Left: {timedelta}]"
+                            "[Last active: {last_activity}] "
+                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
-                            added=datetime.fromtimestamp(torrent.added_on),
                             progress=round(torrent.progress * 100, 2),
+                            availability=round(torrent.availability * 100, 2),
+                            added=datetime.fromtimestamp(torrent.added_on),
+                            timedelta=timedelta(seconds=torrent.eta),
+                            last_activity=datetime.fromtimestamp(torrent.last_activity),
                         )
                         self.delete.add(torrent.hash)
                 # Ignore torrents who have reached maximum percentage as long as the last activity is within the MaximumETA set for this category
@@ -1681,18 +1725,31 @@ class Arr:
                     if torrent.last_activity < time_now - self.maximum_eta:
                         self.logger.info(
                             "Deleting Stale torrent: "
-                            "[Progress: {progress}%][Last active: {last_activity}] | "
-                            "({torrent.hash}) {torrent.name}",
+                            "[Progress: {progress}%][Added On: {added}]"
+                            "[Availability: {availability}%][Time Left: {timedelta}]"
+                            "[Last active: {last_activity}] "
+                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
                             progress=round(torrent.progress * 100, 2),
+                            availability=round(torrent.availability * 100, 2),
+                            added=datetime.fromtimestamp(torrent.added_on),
+                            timedelta=timedelta(seconds=torrent.eta),
                             last_activity=datetime.fromtimestamp(torrent.last_activity),
                         )
                         self.delete.add(torrent.hash)
                     else:
                         self.logger.trace(
-                            "Skipping torrent: Reached Maximum completed percentage and is "
-                            "active | {torrent.name} ({torrent.hash})",
+                            "Skipping torrent: Reached Maximum completed percentage and is active | "
+                            "[Progress: {progress}%][Added On: {added}]"
+                            "[Availability: {availability}%][Time Left: {timedelta}]"
+                            "[Last active: {last_activity}] "
+                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
+                            progress=round(torrent.progress * 100, 2),
+                            availability=round(torrent.availability * 100, 2),
+                            added=datetime.fromtimestamp(torrent.added_on),
+                            timedelta=timedelta(seconds=torrent.eta),
+                            last_activity=datetime.fromtimestamp(torrent.last_activity),
                         )
                         continue
                 # Resume monitored downloads which have been paused.
@@ -1703,8 +1760,17 @@ class Arr:
                     self.timed_ignore_cache.add(torrent.hash)
                     self.resume.add(torrent.hash)
                     self.logger.debug(
-                        "Resuming incomplete paused torrent: {torrent.name} ({torrent.hash})",
+                        "Resuming incomplete paused torrent: "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                 # Ignore torrents which have been submitted to their respective Arr instance for import.
                 elif (
@@ -1712,18 +1778,37 @@ class Arr:
                     in self.manager.managed_objects[torrent.category].sent_to_scan_hashes
                 ) and torrent.hash in self.cleaned_torrents:
                     self.logger.trace(
-                        "Skipping torrent: Already sent for import | {torrent.name} ({torrent.hash})",
+                        "Skipping torrent: Already sent for import | "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     continue
                 # Some times torrents will error, this causes them to be rechecked so they complete downloading.
                 elif torrent.state_enum == TorrentStates.ERROR:
-                    self.logger.info(
-                        "Rechecking Erroed torrent: {torrent.name} ({torrent.hash})",
+                    self.logger.trace(
+                        "Rechecking Erroed torrent: "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.recheck.add(torrent.hash)
-                # If a torrent was not just added, and the amount left to download is 0 and the torrent is Paused tell the Arr tools to process it.
+                # If a torrent was not just added, and the amount left to download is 0 and the torrent
+                # is Paused tell the Arr tools to process it.
                 elif (
                     torrent.added_on > 0
                     and torrent.completion_on
@@ -1735,8 +1820,16 @@ class Arr:
                 ):
                     self.logger.info(
                         "Pausing Completed torrent: "
-                        "{torrent.name} ({torrent.hash}) | {torrent.state_enum}",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.pause.add(torrent.hash)
                     self.skip_blacklist.add(torrent.hash)
@@ -1745,8 +1838,17 @@ class Arr:
                 # this ensures that we can safelly remove it if the client is reporting the status of the client as "Missing files"
                 elif torrent.state_enum == TorrentStates.MISSING_FILES:
                     self.logger.info(
-                        "Deleting torrent with missing files: {torrent.name} ({torrent.hash})",
+                        "Deleting torrent with missing files: "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     # We do not want to blacklist these!!
                     self.skip_blacklist.add(torrent.hash)
@@ -1761,8 +1863,16 @@ class Arr:
                 ) and torrent.hash in self.cleaned_torrents:
                     self.logger.info(
                         "Pausing uploading torrent: "
-                        "{torrent.name} ({torrent.hash}) | {torrent.state_enum}",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.pause.add(torrent.hash)
                     self.skip_blacklist.add(torrent.hash)
@@ -1777,28 +1887,38 @@ class Arr:
                 ):
                     self.logger.trace(
                         "Deleting slow torrent: "
-                        "[Progress: {progress}%][Time Left: {timedelta}] | "
-                        "{torrent.name} ({torrent.hash})",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
-                        timedelta=timedelta(seconds=torrent.eta),
                         progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.delete.add(torrent.hash)
                 # Process uncompleted torrents
                 elif torrent.state_enum.is_downloading:
-                    # If a torrent availability hasn't reached 100% or more within the configurable "IgnoreTorrentsYoungerThan" variable, mark it for deletion.
+                    # If a torrent availability hasn't reached 100% or more within the configurable
+                    # "IgnoreTorrentsYoungerThan" variable, mark it for deletion.
                     if (
                         self.recently_queue.get(torrent.hash, torrent.added_on)
                         < time_now - self.ignore_torrents_younger_than
                         and torrent.availability < 1
                     ) and torrent.hash in self.cleaned_torrents:
-                        self.logger.info(
-                            "Deleting Stale torrent: "
-                            "[Progress: {progress}%][Availability: {availability}%]"
-                            "[Last active: {last_activity}] | {torrent.name} ({torrent.hash})",
+                        self.logger.trace(
+                            "Deleting stale torrent: "
+                            "[Progress: {progress}%][Added On: {added}]"
+                            "[Availability: {availability}%][Time Left: {timedelta}]"
+                            "[Last active: {last_activity}] "
+                            "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                             torrent=torrent,
                             progress=round(torrent.progress * 100, 2),
                             availability=round(torrent.availability * 100, 2),
+                            added=datetime.fromtimestamp(torrent.added_on),
+                            timedelta=timedelta(seconds=torrent.eta),
                             last_activity=datetime.fromtimestamp(torrent.last_activity),
                         )
                         self.delete.add(torrent.hash)
@@ -1806,8 +1926,16 @@ class Arr:
                         if torrent.hash in self.cleaned_torrents:
                             self.logger.trace(
                                 "Skipping file check: Already been cleaned up | "
-                                "{torrent.name} ({torrent.hash}) ",
+                                "[Progress: {progress}%][Added On: {added}]"
+                                "[Availability: {availability}%][Time Left: {timedelta}]"
+                                "[Last active: {last_activity}] "
+                                "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                                 torrent=torrent,
+                                progress=round(torrent.progress * 100, 2),
+                                availability=round(torrent.availability * 100, 2),
+                                added=datetime.fromtimestamp(torrent.added_on),
+                                timedelta=timedelta(seconds=torrent.eta),
+                                last_activity=datetime.fromtimestamp(torrent.last_activity),
                             )
                             continue
                         # A downloading torrent is not stalled, parse its contents.
@@ -1821,7 +1949,8 @@ class Arr:
                             if file.priority == 0:
                                 total -= 1
                                 continue
-                            # A folder within the folder tree matched the terms in FolderExclusionRegex, mark it for exclusion.
+                            # A folder within the folder tree matched the terms
+                            # in FolderExclusionRegex, mark it for exclusion.
                             if any(
                                 self.folder_exclusion_regex_re.search(p.name.lower())
                                 for p in file_path.parents
@@ -1863,8 +1992,16 @@ class Arr:
                             if total == 0:
                                 self.logger.info(
                                     "Deleting All files ignored: "
-                                    "{torrent.name} ({torrent.hash})",
+                                    "[Progress: {progress}%][Added On: {added}]"
+                                    "[Availability: {availability}%][Time Left: {timedelta}]"
+                                    "[Last active: {last_activity}] "
+                                    "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                                     torrent=torrent,
+                                    progress=round(torrent.progress * 100, 2),
+                                    availability=round(torrent.availability * 100, 2),
+                                    added=datetime.fromtimestamp(torrent.added_on),
+                                    timedelta=timedelta(seconds=torrent.eta),
+                                    last_activity=datetime.fromtimestamp(torrent.last_activity),
                                 )
                                 self.delete.add(torrent.hash)
                             # Mark all bad files and folder for exclusion.
@@ -1877,8 +2014,17 @@ class Arr:
 
                 else:
                     self.logger.trace(
-                        "Skipping torrent: Unresolved state | {torrent.name} ({torrent.hash})",
+                        "Skipping torrent: Unresolved state: "
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
+                        progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
             self.process()
         except NoConnectionrException as e:
@@ -2110,23 +2256,23 @@ class Arr:
             except DelayLoopException as e:
                 if e.type == "qbit":
                     self.logger.critical(
-                        "Failed to connected to qBit client, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to qBit client, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "internet":
                     self.logger.critical(
-                        "Failed to connected to the internet, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to the internet, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "arr":
                     self.logger.critical(
-                        "Failed to connected to the Arr instance, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to the Arr instance, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "delay":
                     self.logger.critical(
-                        "Forced delay due to temporary issue with environment, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Forced delay due to temporary issue with environment, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 time.sleep(e.length)
 
@@ -2183,23 +2329,23 @@ class Arr:
             except DelayLoopException as e:
                 if e.type == "qbit":
                     self.logger.critical(
-                        "Failed to connected to qBit client, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to qBit client, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "internet":
                     self.logger.critical(
-                        "Failed to connected to the internet, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to the internet, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "arr":
                     self.logger.critical(
-                        "Failed to connected to the Arr instance, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to the Arr instance, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "delay":
                     self.logger.critical(
-                        "Forced delay due to temporary issue with environment, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Forced delay due to temporary issue with environment, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 time.sleep(e.length)
                 self.manager.qbit_manager.should_delay_torrent_scan = False
@@ -2231,23 +2377,23 @@ class Arr:
             except DelayLoopException as e:
                 if e.type == "qbit":
                     self.logger.critical(
-                        "Failed to connected to qBit client, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to qBit client, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "internet":
                     self.logger.critical(
-                        "Failed to connected to the internet, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to the internet, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "arr":
                     self.logger.critical(
-                        "Failed to connected to the Arr instance, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Failed to connected to the Arr instance, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 elif e.type == "delay":
                     self.logger.critical(
-                        "Forced delay due to temporary issue with environment, sleeping for %s."
-                        % timedelta(seconds=e.length)
+                        "Forced delay due to temporary issue with environment, sleeping for {time}.",
+                        time=timedelta(seconds=e.length),
                     )
                 time.sleep(e.length)
                 self.manager.qbit_manager.should_delay_torrent_scan = False
@@ -2367,22 +2513,32 @@ class PlaceHolderArr(Arr):
                 if torrent.category == FAILED_CATEGORY:
                     self.logger.notice(
                         "Deleting manually failed torrent: "
-                        "[Progress: {progress}%][Time Left: {timedelta}] | "
-                        "{torrent.name} ({torrent.hash})",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
-                        timedelta=timedelta(seconds=torrent.eta),
                         progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.delete.add(torrent.hash)
                 # Bypass everything else if manually marked for rechecking
                 elif torrent.category == RECHECK_CATEGORY:
                     self.logger.notice(
                         "Re-cheking manually set torrent: "
-                        "[Progress: {progress}%][Time Left: {timedelta}] | "
-                        "{torrent.name} ({torrent.hash})",
+                        "[Progress: {progress}%][Added On: {added}]"
+                        "[Availability: {availability}%][Time Left: {timedelta}]"
+                        "[Last active: {last_activity}] "
+                        "| [State:torrent.state_enum] | {torrent.name} ({torrent.hash})",
                         torrent=torrent,
-                        timedelta=timedelta(seconds=torrent.eta),
                         progress=round(torrent.progress * 100, 2),
+                        availability=round(torrent.availability * 100, 2),
+                        added=datetime.fromtimestamp(torrent.added_on),
+                        timedelta=timedelta(seconds=torrent.eta),
+                        last_activity=datetime.fromtimestamp(torrent.last_activity),
                     )
                     self.recheck.add(torrent.hash)
             self.process()

--- a/qBitrr/config.py
+++ b/qBitrr/config.py
@@ -2,7 +2,10 @@ import configparser
 import contextlib
 import pathlib
 import shutil
+import sys
 from datetime import datetime
+
+import logbook
 
 CONFIG = configparser.ConfigParser(
     converters={
@@ -17,13 +20,22 @@ CONFIG = configparser.ConfigParser(
 APPDATA_FOLDER = pathlib.Path().home().joinpath(".config", "qBitManager")
 APPDATA_FOLDER.mkdir(parents=True, exist_ok=True)
 COPIED_TO_NEW_DIR = False
-if (CONFIG_PATH := APPDATA_FOLDER.joinpath("config.ini")).exists():
+CONFIG_FILE = APPDATA_FOLDER.joinpath("config.ini")
+if (
+    not (CONFIG_PATH := APPDATA_FOLDER.joinpath("config.ini")).exists()
+    and not pathlib.Path("./config.ini").exists()
+):
+    logbook.critical("config.ini has not been found - exiting...")
+    sys.exit(1)
+
+if CONFIG_PATH.exists():
     CONFIG.read(str(CONFIG_PATH))
 else:
     with contextlib.suppress(
         Exception
     ):  # If file already exist or can't copy to APPDATA_FOLDER ignore the exception
-        shutil.copy(pathlib.Path("./config.ini"), CONFIG_PATH)
+        CONFIG_FILE = pathlib.Path("./config.ini")
+        shutil.copy(CONFIG_FILE, CONFIG_PATH)
         COPIED_TO_NEW_DIR = True
     CONFIG.read("./config.ini")
 

--- a/qBitrr/logger.py
+++ b/qBitrr/logger.py
@@ -135,12 +135,11 @@ def run_logs():
 if not HAS_RUN:
     if not APPDATA_FOLDER.joinpath("config.ini").exists():
         logbook.warning(
-            "Config.ini should exist in '{APPDATA_FOLDER}', in a future update this will be a requirement.".format(
-                APPDATA_FOLDER=APPDATA_FOLDER
-            )
+            "Config.ini should exist in '{APPDATA_FOLDER}', in a future update this will be a requirement.",
+            APPDATA_FOLDER=APPDATA_FOLDER,
         )
     if COPIED_TO_NEW_DIR:
         logbook.warning(
-            "Config.ini new location is {APPDATA_FOLDER}".format(APPDATA_FOLDER=APPDATA_FOLDER)
+            "Config.ini new location is {APPDATA_FOLDER}", APPDATA_FOLDER=APPDATA_FOLDER
         )
     run_logs()

--- a/qBitrr/logger.py
+++ b/qBitrr/logger.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 
 import logbook
 from logbook import StreamHandler
@@ -138,8 +139,10 @@ if not HAS_RUN:
             "Config.ini should exist in '{APPDATA_FOLDER}', in a future update this will be a requirement.",
             APPDATA_FOLDER=APPDATA_FOLDER,
         )
+        time.sleep(5)
     if COPIED_TO_NEW_DIR:
         logbook.warning(
             "Config.ini new location is {APPDATA_FOLDER}", APPDATA_FOLDER=APPDATA_FOLDER
         )
+        time.sleep(5)
     run_logs()

--- a/qBitrr/utils.py
+++ b/qBitrr/utils.py
@@ -19,7 +19,7 @@ def absolute_file_paths(directory: Union[pathlib.Path, str]) -> Iterator[pathlib
                 yield path
             error = False
         except FileNotFoundError as e:
-            logger.warning("%s - %s" % (e.strerror, e.filename))
+            logger.warning("{e.strerror} - {e.filename}", e=e)
 
 
 def validate_and_return_torrent_file(file: str) -> pathlib.Path:


### PR DESCRIPTION
- Increase verbosity of logs to show several details for every torrent line logged, these include current torrent state, when it was added, when the last activity was recorded, current progress, current availability and how much time is left on download.

- fix a few typos and update the example image in README.md
- Make the script early exit with an error message if `config.ini` can't be located
